### PR TITLE
Support for enterprise demos on AWS

### DIFF
--- a/src/config/nginx/localhost.conf
+++ b/src/config/nginx/localhost.conf
@@ -10,10 +10,15 @@ server {
     server_name localhost;
     charset utf-8;
 
-    location ~ ^/code/(?<library>.+)/(?<version>.+)/(?<directory>demo|assets|static)/(?<path>.+)$ {
-            resolver 127.0.0.11;
-            proxy_pass http://localhost/api/docs/$library/$version/$directory/$path;
-        }
+    location ~ ^/code/ids-enterprise/(\d+).(\d+).(\d+)/demo/(?<path>.+)$ {
+        resolver 127.0.0.11;
+        proxy_pass http://$1$2$3-enterprise.demo.design.infor.com/components/$path;
+    }
+
+    location ~ ^/code/(?<library>ids-css|ids-pendo)/(?<version>.+)/(?<directory>demo|assets|static)/(?<path>.+)$ {
+        resolver 127.0.0.11;
+        proxy_pass https://localhost/api/docs/$library/$version/$directory/$path;
+    }
 
     location / {
         index index.html;

--- a/src/config/nginx/localhost.conf
+++ b/src/config/nginx/localhost.conf
@@ -10,9 +10,14 @@ server {
     server_name localhost;
     charset utf-8;
 
+    location ~ ^/code/ids-enterprise/latest/demo/(?<path>.+)$ {
+        resolver 127.0.0.11;
+        proxy_pass http://latest-enterprise.demo.design.infor.com/components/$path$is_args$args;
+    }
+
     location ~ ^/code/ids-enterprise/(\d+).(\d+).(\d+)/demo/(?<path>.+)$ {
         resolver 127.0.0.11;
-        proxy_pass http://$1$2$3-enterprise.demo.design.infor.com/components/$path;
+        proxy_pass http://$1$2$3-enterprise.demo.design.infor.com/components/$path$is_args$args;
     }
 
     location ~ ^/code/(?<library>ids-css|ids-pendo)/(?<version>.+)/(?<directory>demo|assets|static)/(?<path>.+)$ {

--- a/src/config/nginx/prod.conf
+++ b/src/config/nginx/prod.conf
@@ -21,7 +21,15 @@ server {
     include /etc/nginx/snippets/certificates.conf;
     include /etc/nginx/snippets/ssl.conf;
 
-    location ~ ^/code/(?<library>.+)/(?<version>.+)/(?<directory>demo|assets|static)/(?<path>.+)$ {
+    location ~ ^/code/ids-enterprise/latest/demo/(?<path>.+)$ {
+        return 302 http://latest-enterprise.demo.design.infor.com/components/$path$is_args$args;
+    }
+
+    location ~ ^/code/ids-enterprise/(\d+).(\d+).(\d+)/demo/(?<path>.+)$ {
+        return 302 http://$1$2$3-enterprise.demo.design.infor.com/components/$path$is_args$args;
+    }
+
+    location ~ ^/code/(?<library>ids-css|ids-pendo)/(?<version>.+)/(?<directory>demo|assets|static)/(?<path>.+)$ {
         proxy_pass https://127.0.0.1/api/docs/$library/$version/$directory/$path;
     }
 

--- a/src/config/nginx/staging.conf
+++ b/src/config/nginx/staging.conf
@@ -21,7 +21,15 @@ server {
     include /etc/nginx/snippets/certificates-staging.conf;
     include /etc/nginx/snippets/ssl.conf;
 
-    location ~ ^/code/(?<library>.+)/(?<version>.+)/(?<directory>demo|assets|static)/(?<path>.+)$ {
+    location ~ ^/code/ids-enterprise/latest/demo/(?<path>.+)$ {
+        return 302 http://latest-enterprise.demo.design.infor.com/components/$path$is_args$args;
+    }
+
+    location ~ ^/code/ids-enterprise/(\d+).(\d+).(\d+)/demo/(?<path>.+)$ {
+        return 302 http://$1$2$3-enterprise.demo.design.infor.com/components/$path$is_args$args;
+    }
+
+    location ~ ^/code/(?<library>ids-css|ids-pendo)/(?<version>.+)/(?<directory>demo|assets|static)/(?<path>.+)$ {
         proxy_pass https://127.0.0.1/api/docs/$library/$version/$directory/$path;
     }
 

--- a/src/web/src/app/components/docs-content-page/docs-content-page.component.html
+++ b/src/web/src/app/components/docs-content-page/docs-content-page.component.html
@@ -31,7 +31,6 @@
 
         <ul *ngIf="docs?.demo?.pages">
           <li *ngFor="let demo of docs.demo.pages">
-
             <a href="{{absolutePath}}/demo/{{element}}/{{demo.slug}}?font=source-sans" target="_blank">{{demo.name}}</a>
           </li>
         </ul>

--- a/src/web/src/app/components/docs-content-page/docs-content-page.component.html
+++ b/src/web/src/app/components/docs-content-page/docs-content-page.component.html
@@ -31,7 +31,8 @@
 
         <ul *ngIf="docs?.demo?.pages">
           <li *ngFor="let demo of docs.demo.pages">
-            <a href="http://sohobeta.infor.com/{{selectedVersionNumber}}/components/{{element}}/{{demo.slug}}?font=source-sans" target="_blank">{{demo.name}}</a>
+
+            <a href="{{absolutePath}}/demo/{{element}}/{{demo.slug}}?font=source-sans" target="_blank">{{demo.name}}</a>
           </li>
         </ul>
 


### PR DESCRIPTION
Currently just redirects the `/code/ids-enterprise/latest/demo/` and `/code/ids-enterprise/(\d+).(\d+).(\d+)/demo/` paths to the new enterprise app demo sites but I'd like to proxy them (like the `/code/ids-css/latest/demo/` URLs work) once we get a few issues sorted out there.

To test:

* check out branch
* make restart
* npm start
* go to http://localhost/code/ids-enterprise/latest/about and click "Default About Example"
    * You should end up on a URL http://localhost/code/ids-enterprise/latest/demo/about/example-index?font=source-sans which shows the "About" example
* go to http://localhost/code/ids-enterprise/4.6.0/badges and click "Default Badge Example"
    * You should be taken to http://localhost/code/ids-enterprise/4.6.0/demo/badges/example-index?font=source-sans in a new tab

***

Currently on staging and prod for `ids-enterprise`, you'll be redirected to something like: http://latest-enterprise.demo.design.infor.com/components/badges/example-index?font=source-sans

In the future, this should just proxy like is working on localhost.