### PR TITLE
Remove feedback widget from 404 pages

### DIFF
--- a/src/web/src/app/components/block-page/block-page.component.html
+++ b/src/web/src/app/components/block-page/block-page.component.html
@@ -55,7 +55,9 @@
 
       </div>
 
-      <feedback-widget *ngIf="!loading"></feedback-widget>
+      <ng-container *ngIf="!notFound">
+        <feedback-widget *ngIf="!loading"></feedback-widget>
+      </ng-container>
 
     </div>
 

--- a/src/web/src/app/components/block-page/block-page.component.html
+++ b/src/web/src/app/components/block-page/block-page.component.html
@@ -55,9 +55,7 @@
 
       </div>
 
-      <ng-container *ngIf="!notFound">
-        <feedback-widget *ngIf="!loading"></feedback-widget>
-      </ng-container>
+      <feedback-widget *ngIf="!loading" [notFound]="notFound"></feedback-widget>
 
     </div>
 

--- a/src/web/src/app/components/core-content-page/core-content-page.component.html
+++ b/src/web/src/app/components/core-content-page/core-content-page.component.html
@@ -61,9 +61,7 @@
 
       </div>
 
-      <ng-container *ngIf="!notFound">
-        <feedback-widget *ngIf="!loading"></feedback-widget>
-      </ng-container>
+      <feedback-widget *ngIf="!loading" [notFound]="notFound"></feedback-widget>
 
     </div>
 

--- a/src/web/src/app/components/core-content-page/core-content-page.component.html
+++ b/src/web/src/app/components/core-content-page/core-content-page.component.html
@@ -61,7 +61,9 @@
 
       </div>
 
-      <feedback-widget *ngIf="!loading"></feedback-widget>
+      <ng-container *ngIf="!notFound">
+        <feedback-widget *ngIf="!loading"></feedback-widget>
+      </ng-container>
 
     </div>
 

--- a/src/web/src/app/components/docs-content-page/docs-content-page.component.html
+++ b/src/web/src/app/components/docs-content-page/docs-content-page.component.html
@@ -45,9 +45,7 @@
 
     </div>
 
-    <ng-container *ngIf="!notFound">
-      <feedback-widget *ngIf="!loading"></feedback-widget>
-    </ng-container>
+    <feedback-widget *ngIf="!loading" [notFound]="notFound"></feedback-widget>
 
   </div>
 

--- a/src/web/src/app/components/docs-content-page/docs-content-page.component.html
+++ b/src/web/src/app/components/docs-content-page/docs-content-page.component.html
@@ -45,7 +45,9 @@
 
     </div>
 
-    <feedback-widget *ngIf="!loading"></feedback-widget>
+    <ng-container *ngIf="!notFound">
+      <feedback-widget *ngIf="!loading"></feedback-widget>
+    </ng-container>
 
   </div>
 

--- a/src/web/src/app/components/element-page/element-page.component.html
+++ b/src/web/src/app/components/element-page/element-page.component.html
@@ -64,7 +64,9 @@
 
       </div>
 
-      <feedback-widget *ngIf="!loading"></feedback-widget>
+      <ng-container *ngIf="!notFound">
+        <feedback-widget *ngIf="!loading"></feedback-widget>
+      </ng-container>
 
     </div>
 

--- a/src/web/src/app/components/element-page/element-page.component.html
+++ b/src/web/src/app/components/element-page/element-page.component.html
@@ -64,9 +64,7 @@
 
       </div>
 
-      <ng-container *ngIf="!notFound">
-        <feedback-widget *ngIf="!loading"></feedback-widget>
-      </ng-container>
+      <feedback-widget *ngIf="!loading" [notFound]="notFound"></feedback-widget>
 
     </div>
 

--- a/src/web/src/app/components/feedback-widget/feedback-widget.component.html
+++ b/src/web/src/app/components/feedback-widget/feedback-widget.component.html
@@ -1,5 +1,5 @@
 
-<div (mouseenter)="!widgetHovered ? captureHover($event) : null" class="feedback-widget">
+<div *ngIf="!notFound" (mouseenter)="!widgetHovered ? captureHover($event) : null" class="feedback-widget">
   <fieldset class="ids-form-group ids-form-group--feedback">
     <div class="ids-form-group--feedback-container">
       <legend>Was this helpful?</legend>

--- a/src/web/src/app/components/feedback-widget/feedback-widget.component.ts
+++ b/src/web/src/app/components/feedback-widget/feedback-widget.component.ts
@@ -1,4 +1,4 @@
-import { Component, AfterViewInit, ElementRef, ViewChild } from '@angular/core';
+import { Component, AfterViewInit, ElementRef, ViewChild, Input } from '@angular/core';
 import { Router, ActivatedRoute, NavigationEnd } from '@angular/router';
 
 @Component({
@@ -8,6 +8,7 @@ import { Router, ActivatedRoute, NavigationEnd } from '@angular/router';
 export class FeedbackWidgetComponent implements AfterViewInit {
   @ViewChild('thumbsDown') thumbsDown: ElementRef;
   @ViewChild('thumbsUp') thumbsUp: ElementRef;
+  @Input() notFound;
   public widgetHovered = false;
   public thumbValue;
   public maxLength = 1500;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Adds check for "notFound" on the feedback widget so that it doesn't show on 404 pages

**Related github/jira issue (required)**:
closes #595 
