### PR TITLE
Fix list items on blog posts

### DIFF
--- a/src/web/src/css/components/blog.css
+++ b/src/web/src/css/components/blog.css
@@ -14,6 +14,11 @@
   &:last-child {
     border-bottom: none;
   }
+
+  & li {
+    list-style-position: outside;
+    margin-left: 2rem;
+  }
 }
 
 .blog-post--container {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Adds margin left to list items in blog posts so they are not outside the content area.

**Related github/jira issue (required)**:
closes #605 
