### PR TITLE
What happened to SoHo modal

### DIFF
--- a/src/web/src/app/app.component.html
+++ b/src/web/src/app/app.component.html
@@ -13,3 +13,15 @@
   </div>
 
 </div>
+
+<div *ngIf="sohoModalVisible" class="modal modal--soho-redirect">
+  <button (click)="closeSohoModal()" type="button" class="ids-btn ids-btn--link modal--close" title="Star icon beside text button">
+    <svg class="ids-icon" focusable="false" aria-hidden="true" role="presentation">
+      <use xlink:href="#icon_close"></use>
+    </svg>
+  </button>
+  <h2>What Happened to soho?</h2>
+  <p>Don't worry. We're not depreating the 4.x controls. Instead, we have defined a system of improved guidelines and documentation for the usage of the Enterprise controls (SoHo controls) called the Infor Design System, A.K.A IDS. Now, you can find everything you were looking for on soho.infor.com (and more) right here.</p>
+</div>
+
+<div *ngIf="sohoModalVisible" class="modal-overlay"></div>

--- a/src/web/src/app/app.component.ts
+++ b/src/web/src/app/app.component.ts
@@ -18,6 +18,7 @@ export class AppComponent {
   public section;
   public sidebarNav;
   public footerNav;
+  public sohoModalVisible = false;
 
   constructor(
     private router: Router,
@@ -96,6 +97,8 @@ export class AppComponent {
         }
       );
 
+    this.showSohoModal();
+
   }
 
   public capitalizeTitle(str) {
@@ -116,6 +119,17 @@ export class AppComponent {
       }
     } catch (e) { }
     return 'false';
+  }
+
+  public showSohoModal() {
+    const referrer = document.referrer;
+    if (referrer === 'https://soho.infor.com/') {
+      this.sohoModalVisible = true;
+    }
+  }
+
+  public closeSohoModal() {
+    this.sohoModalVisible = false;
   }
 
 }

--- a/src/web/src/css/components/modal.css
+++ b/src/web/src/css/components/modal.css
@@ -1,0 +1,31 @@
+
+.modal {
+  background-color: var(--white);
+  left: 50%;
+  max-width: 600px;
+  min-width: 300px;
+  padding: calc(var(--spacing-base) * 10) calc(var(--spacing-base) * 5);
+  position: fixed;
+  text-align: center;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: 90%;
+  z-index: 1001;
+}
+
+.modal--close {
+  position: absolute;
+  right: -10px;
+  top: 10px;
+}
+
+.modal-overlay {
+  background: var(--black);
+  height: 100%;
+  left: 0;
+  opacity: 0.7;
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: 1000;
+}

--- a/src/web/src/css/site.css
+++ b/src/web/src/css/site.css
@@ -31,3 +31,4 @@
 @import './components/jsdoc.css';
 @import './components/feedback.css';
 @import './components/toc.css';
+@import './components/modal.css';


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
I added modal to explain what happened to the original enterprise website. It only appears when referring url is `https://soho.infor.com`.

**Related github/jira issue (required)**:
Closes #509 

