### PR TITLE
Use deployed ids-identity tokens

### DIFF
--- a/src/web/src/app/components/modifiers-table/modifiers-table.component.ts
+++ b/src/web/src/app/components/modifiers-table/modifiers-table.component.ts
@@ -19,7 +19,7 @@ export class ModifiersTableComponent implements OnInit {
   ) {}
 
   ngOnInit() {
-    this.getIDSTokenProperties(this.appSettings.domainDocsApi, 'ids-css');
+    this.getIDSTokenProperties(this.appSettings.domainDocsApi, 'ids-identity');
     this.checkModifierTokens();
   }
 

--- a/src/web/src/app/components/token-table/token-table.component.ts
+++ b/src/web/src/app/components/token-table/token-table.component.ts
@@ -21,7 +21,7 @@ export class TokenTableComponent implements OnInit {
   ) {}
 
   ngOnInit() {
-    this.getIDSTokenProperties(this.appSettings.domainDocsApi, 'ids-css', this.version);
+    this.getIDSTokenProperties(this.appSettings.domainDocsApi, 'ids-identity');
   }
 
   private getIDSTokenProperties(domain: string, library: string, version: string = 'latest') {

--- a/src/web/src/app/shared/token.service.spec.ts
+++ b/src/web/src/app/shared/token.service.spec.ts
@@ -27,7 +27,7 @@ describe('TokenService', () => {
     const testDomain = 'domain';
     const testLibrary = 'library';
     const testVersion = 'version';
-    const testUrl = `${testDomain}/api/docs/${testLibrary}/${testVersion}/ids-identity/theme-default.raw.json`;
+    const testUrl = `${testDomain}/api/docs/${testLibrary}/${testVersion}/tokens/web/theme-soho.raw.json`;
     const testData = { title: 'Test' };
 
     beforeEach(() => {

--- a/src/web/src/app/shared/token.service.ts
+++ b/src/web/src/app/shared/token.service.ts
@@ -18,7 +18,7 @@ export class TokenService {
   getTokenData(domain: string, library: string, version: string) {
     // Note that the following url route is for a dist file
     // and not referring to the ids-identity packing in node_modules
-    const url = `${domain}/api/docs/${library}/${version}/ids-identity/theme-default.raw.json`;
+    const url = `${domain}/api/docs/${library}/${version}/tokens/web/theme-soho.raw.json`;
 
    return this.cacheService.get(url, this.http
     .get(url)


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Uses the tokens in the Docs API rather than the tokens uploaded with the CSS library.

**Related github/jira issue (required)**:
https://github.com/infor-design/design-system/pull/191

**Steps necessary to review your pull request (required)**:
1. Pull PR, there's no need to deploy any new docs as they're already on the staging API.
1. Edit 'Pill' page: http://localhost/admin/pages/31/edit/
1. Add `pills` to Tokens Category section in page
1. Publish page
1. If page properly shows tokens in 'Design Tokens' section, site is properly pulling from `ids-identity` on Docs API

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
