### PR TITLE
650 - Fixes semver issue not showing latest

### DIFF
--- a/deploy-aws/prod-Dockerrun.aws.json
+++ b/deploy-aws/prod-Dockerrun.aws.json
@@ -63,7 +63,7 @@
 	}],
 	"containerDefinitions": [{
 		"name": "backend",
-		"image": "hookandloop/docs-backend:1.0.3",
+		"image": "hookandloop/docs-backend:1.0.4",
 		"essential": true,
 		"memory": 1024,
 		"portMappings": [{

--- a/deploy-aws/staging-Dockerrun.aws.json
+++ b/deploy-aws/staging-Dockerrun.aws.json
@@ -68,7 +68,7 @@
 	}],
 	"containerDefinitions": [{
 		"name": "backend",
-		"image": "hookandloop/docs-backend:1.0.3",
+		"image": "hookandloop/docs-backend:1.0.4",
 		"essential": true,
 		"memory": 1024,
 		"portMappings": [{

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
 
   backend:
     build: ./docker/docs-backend
-    image: hookandloop/docs-backend:1.0.3
+    image: hookandloop/docs-backend:1.0.4
     container_name: 'docssite_backend'
     depends_on:
       - postgres

--- a/docker/docs-backend/Makefile
+++ b/docker/docs-backend/Makefile
@@ -2,7 +2,7 @@
 
 ORGANIZATION = hookandloop
 CONTAINER = docs-backend
-VERSION = 1.0.3
+VERSION = 1.0.4
 
 .PHONY: build
 

--- a/docker/docs-backend/requirements/prod.txt
+++ b/docker/docs-backend/requirements/prod.txt
@@ -8,5 +8,5 @@ whitenoise==4.0b4
 Markdown==2.6.9
 wagtail-markdown==0.5a3
 html5lib==0.999999999
-semver==2.7.9
+node-semver==0.3.0
 django-dbbackup==3.2.0

--- a/src/app/docs/aws.py
+++ b/src/app/docs/aws.py
@@ -109,16 +109,7 @@ def get(request):
         if version == 'latest':
             all_versions_paths = get_filtered_result(bucket_name, library_path + "/")
             all_versions = [s.lstrip(library_path).rstrip('/') for s in all_versions_paths]
-            latest_version = '0.0.0'
-
-            if len(all_versions) > 1:
-                for a, b in itertools.combinations(all_versions, 2):
-                    highest_version = semver.max_ver(a, b)
-
-                    if highest_version > latest_version:
-                        latest_version = highest_version
-            else:
-                latest_version = all_versions[0]
+            latest_version = semver.rsort(all_versions, True)[0]
 
             latest_file_pointer = os.path.join(*(
                 library_path,


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

A bug in the former semver plugin was not recognizing `4.10.0` as the latest version.

**Related github/jira issue (required)**:
Closes #650 

**Steps necessary to review your pull request (required)**:

Navigating to http://localhost/code/ids-enterprise/latest/changelog should show you the latest changes is `4.10.0`

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
