### PR TITLE
Kibana images require a specific version number tag

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       - xpack.watcher.enabled=false
 
   kibana:
-    image: kibana
+    image: kibana:6.4.2
     container_name: 'docssite_kibana'
     ports:
       - "5601:5601"


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
As found by @nickwynja per Kibana's [docs](https://hub.docker.com/r/library/kibana/):

> Note: Pulling an images requires using a specific version number tag. The latest tag is not supported.

**Related github/jira issue (required)**:
#669 

**Steps necessary to review your pull request (required)**:
1. Go to the root of this directory
2. `make up`
3. Kibana should pull and the containers should come up as normal.