### PR TITLE
Cast parser input as string

### DIFF
--- a/src/app/docs/aws.py
+++ b/src/app/docs/aws.py
@@ -44,7 +44,7 @@ class MLStripper(HTMLParser):
 
 def strip_tags(input_html):
     s = MLStripper()
-    input_html = re.sub(r'(\n)', ' ', input_html)
+    input_html = re.sub(r'(\n)', ' ', str(input_html))
     lis = list(filter(None, input_html.split(" ")))
     input_html = " ".join(lis)
     s.feed(input_html)
@@ -141,10 +141,10 @@ def post(request):
                         doc['slug'] = doc_slug
                         doc['path'] = path
                     except ValueError as err:
-                        print("ValueError exception... {}".format(err))
+                        print("ValueError exception... {} on {}".format(err, path))
                         continue
                     except KeyError as err:
-                        print("KeyError exception... {}".format(err))
+                        print("KeyError exception... {} on {}".format(err, path))
                         continue
 
                     indexer.index_doc(doc)


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

In some edge cases, an object with a type other than a string would get passed into `strip_tags()` and would error with `expected string or buffer`. This casts `input_html` as a string to ensure this error doesn't happen.

**Steps necessary to review your pull request (required)**:

1. Pull down branch and `make up` or `make reset` if docker container is already running
2. Publish docs to endpoint per the method for each repo (`npm run publish:docs` for `ids-css`)
3. Make sure you get a `200` OK on deploying docs