### PR TITLE
Update django to close vulnerabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,21 @@ make dev_backend #for backend dev
 
 And finally, `make shell_backend` and `chown uwsgi:uwsgi -R /home/app/media/`, if you are working with media files locally.
 
+## Building backend
+
+If you need to update python packages or make other changes to the docker image:
+
+* Update [requirements.txt](https://github.com/infor-design/website/blob/master/src/app/requirements.txt) and/or [prod.txt](https://github.com/infor-design/website/blob/master/docker/docs-backend/requirements/prod.txt)
+* Update references to `docs-backend` version number, as seen in this commit [`f8d57ba`](https://github.com/infor-design/website/commit/f8d57ba91a94607d835c84a712c31dcdd80b6a06)
+* Then build and push the docker container as follows, getting the docker credentials from an admin:
+
+```
+make build_backend
+docker login
+docker push hookandloop/docs-backend:1.0.6
+```
+Make sure to update the `push` command with the version number you just created.
+
 ## ElasticSearch
 
 To browse the indexes through the browser, navigate to here https://localhost:9200/_cat/indices?v

--- a/deploy-aws/prod-Dockerrun.aws.json
+++ b/deploy-aws/prod-Dockerrun.aws.json
@@ -63,7 +63,7 @@
 	}],
 	"containerDefinitions": [{
 		"name": "backend",
-		"image": "hookandloop/docs-backend:1.0.5",
+		"image": "hookandloop/docs-backend:1.0.6",
 		"essential": true,
 		"memory": 1024,
 		"portMappings": [{

--- a/deploy-aws/staging-Dockerrun.aws.json
+++ b/deploy-aws/staging-Dockerrun.aws.json
@@ -68,7 +68,7 @@
 	}],
 	"containerDefinitions": [{
 		"name": "backend",
-		"image": "hookandloop/docs-backend:1.0.5",
+		"image": "hookandloop/docs-backend:1.0.6",
 		"essential": true,
 		"memory": 1024,
 		"portMappings": [{

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,7 @@ services:
 
   backend:
     build: ./docker/docs-backend
-    image: hookandloop/docs-backend:1.0.5
+    image: hookandloop/docs-backend:1.0.6
     container_name: 'docssite_backend'
     depends_on:
       - postgres

--- a/docker/docs-backend/Dockerfile
+++ b/docker/docs-backend/Dockerfile
@@ -1,10 +1,13 @@
-FROM ubuntu:14.04
+FROM ubuntu:18.04
 
 MAINTAINER Hook & Loop Dev <hookandloopjenkins@gmail.com>
 
-RUN locale-gen en_US.UTF-8  
-ENV LANG en_US.UTF-8  
-ENV LANGUAGE en_US:en  
+RUN apt-get clean \
+    && apt-get -y update \
+    && apt-get install -y locales \
+    && locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
 ENV TERM xterm
@@ -14,9 +17,10 @@ RUN apt-get update \
       software-properties-common \
       build-essential \
       wget \
-    && yes | add-apt-repository ppa:fkrull/deadsnakes \
-    && add-apt-repository "deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main"  \
-    && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+    && sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ `lsb_release -cs`-pgdg main" >> /etc/apt/sources.list.d/pgdg.list' \
+    && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+
+ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update \
     && apt-get install -y \
@@ -26,7 +30,7 @@ RUN apt-get update \
       python3 \
       python3-pip \
       python-setuptools \
-      python-software-properties \
+      software-properties-common \
       postgresql-contrib \
       postgresql-9.6 \
       memcached \
@@ -55,8 +59,7 @@ RUN apt-get update \
     && update-locale LANG=en_US.UTF-8 \
     && rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install --upgrade pip \
-  && pip3 install --upgrade distribute \
+RUN python3 -m pip install --upgrade pip \
   && pip3 install --ignore-installed six
 
 ADD ./requirements /home/app/requirements/

--- a/docker/docs-backend/Makefile
+++ b/docker/docs-backend/Makefile
@@ -8,3 +8,6 @@ VERSION = 1.0.6
 
 build :
 	docker build -t $(ORGANIZATION)/$(CONTAINER):$(VERSION) .
+
+rebuild :
+	docker build --no-cache -t $(ORGANIZATION)/$(CONTAINER):$(VERSION) .

--- a/docker/docs-backend/Makefile
+++ b/docker/docs-backend/Makefile
@@ -2,7 +2,7 @@
 
 ORGANIZATION = hookandloop
 CONTAINER = docs-backend
-VERSION = 1.0.5
+VERSION = 1.0.6
 
 .PHONY: build
 

--- a/docker/docs-backend/requirements/prod.txt
+++ b/docker/docs-backend/requirements/prod.txt
@@ -1,6 +1,6 @@
 elasticsearch>=6.0.0,<6.3.1
 requests-aws4auth==0.9
-wagtail==2.1
+wagtail==2.2.2
 django-cors-headers==2.0.0
 django-storages==1.6.5
 psycopg2==2.7.3

--- a/docker/docs-backend/requirements/prod.txt
+++ b/docker/docs-backend/requirements/prod.txt
@@ -1,9 +1,10 @@
+Django==2.1.2
 elasticsearch>=6.0.0,<6.3.1
 requests-aws4auth==0.9
-wagtail==2.2.2
+wagtail==2.3rc2
 django-cors-headers==2.0.0
 django-storages==1.6.5
-psycopg2==2.7.3
+psycopg2==2.7.5
 uwsgi==2.0.15
 boto3==1.4.8
 whitenoise==4.0b4

--- a/src/app/requirements.txt
+++ b/src/app/requirements.txt
@@ -1,2 +1,2 @@
-Django>=2.1.2
-wagtail>=2.2.2
+Django==2.1.2
+wagtail==2.3rc2

--- a/src/app/requirements.txt
+++ b/src/app/requirements.txt
@@ -1,2 +1,2 @@
-Django>=2.0.4,<2.1
-wagtail>=2.0.1,<2.1
+Django>=2.1.2
+wagtail>=2.2.2


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Fixes django vulnerability. Updates image to Ubuntu 18.04, Python 3.6.6, Django 2.1.2 and Wagtail 2.3rc2.

**Related github/jira issue (required)**:

Closes #668 

**Steps necessary to review your pull request (required)**:
1. Pull down branch
2. `make up` or `make restart` if docker setup is already running
3. run `docker exec docssite_backend pip list | grep Django` and make sure it reads `2.1.2`

