### PR TITLE
Only run npm install if it has changed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,8 +66,12 @@ restart_vm :
 
 
 # Web
-run_dev :
-	cd src/web && npm install && npm run start
+node_modules : src/web/package.json
+	cd src/web && npm install
+	touch $@
+
+run_dev : node_modules
+	cd src/web && npm run start
 
 # This is mostly for testing locally.
 build_prod :


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Updates `make run_dev` to only run `npm install` if `package.json` has changed. Uses some `make` magic. 

**Steps necessary to review your pull request (required)**:
1. Pull branch and from root, run `make run_dev`
2. Notice it'll run through an `npm install` (there may or may not be anything to update). You'll see an output at the top like:
```
cd src/web && npm install

up to date in 8.198s
touch node_modules
cd src/web && npm run start
```
3. Let the build finish and kill the server
4. Run `make run_dev` again. This time, you shouldn't see `cd src/web && npm install` as it starts because it's skipping this because the dependent file hasn't changed.