### PR TITLE
Update nginx routes to allow patterns, docs use relative links

### DIFF
--- a/src/config/nginx/localhost.conf
+++ b/src/config/nginx/localhost.conf
@@ -10,10 +10,12 @@ server {
     server_name localhost;
     charset utf-8;
 
-    location ~ ^/code/ids-enterprise/latest/demo/(?<path>.+)$ {
+    rewrite ^/code/ids-enterprise/latest/demo/(.*)/$ /code/ids-enterprise/latest/demo/$1 permanent;
+
+    location ~ ^/code/ids-enterprise/latest/demo/(?<section>components|patterns|layouts|examples)/(?<path>.+)$ {
         resolver 127.0.0.11;
 		proxy_hide_header Content-Security-Policy;
-        proxy_pass http://latest-enterprise.demo.design.infor.com/components/$path$is_args$args;
+        proxy_pass http://1133-demo-app-urls-enterprise.demo.design.infor.com/$section/$path$is_args$args;
     }
 
     # Support for back versions that can't handle proxy

--- a/src/config/nginx/localhost.conf
+++ b/src/config/nginx/localhost.conf
@@ -16,7 +16,7 @@ server {
     location ~ ^/code/ids-enterprise/latest/demo/(?<section>components|patterns|layouts|examples)/(?<path>.+)$ {
         resolver 127.0.0.11;
 		proxy_hide_header Content-Security-Policy;
-        proxy_pass http://1133-demo-app-urls-enterprise.demo.design.infor.com/$section/$path$is_args$args;
+        proxy_pass http://latest-enterprise.demo.design.infor.com/$section/$path$is_args$args;
     }
 
     # Support for back versions that can't handle proxy

--- a/src/config/nginx/localhost.conf
+++ b/src/config/nginx/localhost.conf
@@ -10,6 +10,7 @@ server {
     server_name localhost;
     charset utf-8;
 
+    # Remove trailing slash on demo links to keep proper relative structure
     rewrite ^/code/ids-enterprise/latest/demo/(.*)/$ /code/ids-enterprise/latest/demo/$1 permanent;
 
     location ~ ^/code/ids-enterprise/latest/demo/(?<section>components|patterns|layouts|examples)/(?<path>.+)$ {
@@ -26,23 +27,23 @@ server {
     }
 
     # Matches pre-release versions like `4.12.0-dev`
-    location ~ ^/code/ids-enterprise/(\d+).(\d+).(\d+)-(\w+)/demo/(?<path>.+)$ {
+    location ~ ^/code/ids-enterprise/(\d+).(\d+).(\d+)-(\w+)/demo/(?<section>components|patterns|layouts|examples)/(?<path>.+)$ {
         resolver 127.0.0.11;
 		proxy_hide_header Content-Security-Policy;
-        proxy_pass http://$1$2$3-$4-enterprise.demo.design.infor.com/components/$path$is_args$args;
+        proxy_pass http://$1$2$3-$4-enterprise.demo.design.infor.com/$section/$path$is_args$args;
     }
 
     # Matches pre-release versions like `4.12.0-beta.0`
-    location ~ ^/code/ids-enterprise/(\d+).(\d+).(\d+)-(\w+).(\d+)/demo/(?<path>.+)$ {
+    location ~ ^/code/ids-enterprise/(\d+).(\d+).(\d+)-(\w+).(\d+)/demo/(?<section>components|patterns|layouts|examples)/(?<path>.+)$ {
         resolver 127.0.0.11;
 		proxy_hide_header Content-Security-Policy;
-        proxy_pass http://$1$2$3-$4$5-enterprise.demo.design.infor.com/components/$path$is_args$args;
+        proxy_pass http://$1$2$3-$4$5-enterprise.demo.design.infor.com/$section/$path$is_args$args;
     }
 
-    location ~ ^/code/ids-enterprise/(\d+).(\d+).(\d+)/demo/(?<path>.+)$ {
+    location ~ ^/code/ids-enterprise/(\d+).(\d+).(\d+)/demo/(?<section>components|patterns|layouts|examples)/(?<path>.+)$ {
         resolver 127.0.0.11;
 		proxy_hide_header Content-Security-Policy;
-        proxy_pass http://$1$2$3-enterprise.demo.design.infor.com/components/$path$is_args$args;
+        proxy_pass http://$1$2$3-enterprise.demo.design.infor.com/$section/$path$is_args$args;
     }
 
     location ~ ^/code/(?<library>ids-css|ids-pendo)/(?<version>.+)/(?<directory>demo|assets|static)/(?<path>.+)$ {

--- a/src/config/nginx/snippets/demo-proxy.conf
+++ b/src/config/nginx/snippets/demo-proxy.conf
@@ -2,10 +2,13 @@
 # used in staging and production
 # For localhost, src/config/nginx/localhost.conf
 
-location ~ ^/code/ids-enterprise/latest/demo/(?<path>.+)$ {
+# Remove trailing slash on demo links to keep proper relative structure
+rewrite ^/code/ids-enterprise/latest/demo/(.*)/$ /code/ids-enterprise/latest/demo/$1 permanent;
+
+location ~ ^/code/ids-enterprise/latest/demo/(?<section>components|patterns|layouts|examples)/(?<path>.+)$ {
     resolver 8.8.8.8;
     proxy_hide_header Content-Security-Policy;
-    proxy_pass https://latest-enterprise.demo.design.infor.com/components/$path$is_args$args;
+    proxy_pass https://1133-demo-app-urls-enterprise.demo.design.infor.com/$section/$path$is_args$args;
 }
 
 # Support redirect for back versions that can't handle proxy
@@ -14,25 +17,25 @@ location ~ ^/code/ids-enterprise/4.6.(0|1)/demo/(?<path>.+)$ {
 }
 
 # Matches pre-release versions like `4.12.0-dev`
-location ~ ^/code/ids-enterprise/(\d+).(\d+).(\d+)-(\w+)/demo/(?<path>.+)$ {
+location ~ ^/code/ids-enterprise/(\d+).(\d+).(\d+)-(\w+)/demo/(?<section>components|patterns|layouts|examples)/(?<path>.+)$ {
     resolver 8.8.8.8;
     proxy_hide_header Content-Security-Policy;
     # passes to server like `4120-beta0-enterprise.demo`
-    proxy_pass https://$1$2$3-$4-enterprise.demo.design.infor.com/components/$path$is_args$args;
+    proxy_pass https://$1$2$3-$4-enterprise.demo.design.infor.com/$section/$path$is_args$args;
 }
 
 # Matches pre-release versions like `4.12.0-beta.0`
-location ~ ^/code/ids-enterprise/(\d+).(\d+).(\d+)-(\w+).(\d+)/demo/(?<path>.+)$ {
+location ~ ^/code/ids-enterprise/(\d+).(\d+).(\d+)-(\w+).(\d+)/demo/(?<section>components|patterns|layouts|examples)/(?<path>.+)$ {
     resolver 8.8.8.8;
     proxy_hide_header Content-Security-Policy;
     # passes to server like `4120-beta0-enterprise.demo`
-    proxy_pass https://$1$2$3-$4$5-enterprise.demo.design.infor.com/components/$path$is_args$args;
+    proxy_pass https://$1$2$3-$4$5-enterprise.demo.design.infor.com/$section/$path$is_args$args;
 }
 
-location ~ ^/code/ids-enterprise/(\d+).(\d+).(\d+)/demo/(?<path>.+)$ {
+location ~ ^/code/ids-enterprise/(\d+).(\d+).(\d+)/demo/(?<section>components|patterns|layouts|examples)/(?<path>.+)$ {
     resolver 8.8.8.8;
     proxy_hide_header Content-Security-Policy;
-    proxy_pass https://$1$2$3-enterprise.demo.design.infor.com/components/$path$is_args$args;
+    proxy_pass https://$1$2$3-enterprise.demo.design.infor.com/$section/$path$is_args$args;
 }
 
 location ~ ^/code/ids-enterprise/*\.css$ {

--- a/src/web/src/app/components/docs-content-page/docs-content-page.component.ts
+++ b/src/web/src/app/components/docs-content-page/docs-content-page.component.ts
@@ -272,7 +272,7 @@ export class DocsContentPageComponent implements OnInit, OnDestroy {
   }
 
   createDemoUrl(slug: string, noFrillsDemo: boolean = false) {
-    let url = `${this.absolutePath}/demo/${this.element}/${slug}?font=source-sans`;
+    let url = `${this.absolutePath}/demo/components/${this.element}/${slug}?font=source-sans`;
     if (noFrillsDemo) {
       url += '&nofrills=true';
     }

--- a/src/web/src/app/components/docs-content-page/docs-content-page.component.ts
+++ b/src/web/src/app/components/docs-content-page/docs-content-page.component.ts
@@ -221,7 +221,12 @@ export class DocsContentPageComponent implements OnInit, OnDestroy {
       if (!absolute.test(el.getAttribute(attr))) {
         if (navigate) {
           const relativeLink = el.getAttribute(attr);
-          this.router.navigate([`${relativeLink}`]);
+          const pathArray = relativeLink.split('/');
+          if (pathArray[1] === 'code' && pathArray[4] === 'demo') {
+            window.open(`${window.location.origin}${relativeLink}`, '_blank');
+          } else {
+            this.router.navigate([`${relativeLink}`]);
+          }
         } else {
           const relativeHref = el.getAttribute(attr).replace(/(^\.\/|.html$)/g, '');
           if (relativeHref.substring(0, 1) === '/') {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
- Updates the nginx routes to proxy links to `components|patterns|layouts|examples`
- Updates app's relative link handling so it opens relative links to demos in a new tab

**Related github/jira issue (required)**:
Closes #680, closes #688 

Relates to infor-design/enterprise#1133

**Steps necessary to review your pull request (required)**:

Since a combination of environments need to configured, I've staged the environments to confirm everything is working. Please check that the following links:

* Demos are working normally on https://staging.design.infor.com/code/ids-enterprise/latest/button
* Links between docs are working: go to [multi-select](https://staging.design.infor.com/code/ids-enterprise/latest/multiselect) and scroll down below the API details and click on the `dropdown` link
* The following listing pages work:
    * https://staging.design.infor.com/code/ids-enterprise/latest/demo/components/contextualactionpanel
    * https://staging.design.infor.com/code/ids-enterprise/latest/demo/patterns/list
    * https://staging.design.infor.com/code/ids-enterprise/latest/demo/layouts/list
* Links from the `/patterns/list` and `/layouts/list` to individual items works as expected.

Known issue: links from `/examples/list` won't work. This is probably fine.

⚠️ **NOTE**: Please don't merge this. After review and approval, I need to change some configuration so that it works normally in production. ⚠️ 

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
