### PR TITLE
708 - Only have the iframe use the nofrills url

### DIFF
--- a/src/web/src/app/components/docs-content-page/docs-content-page.component.ts
+++ b/src/web/src/app/components/docs-content-page/docs-content-page.component.ts
@@ -125,8 +125,8 @@ export class DocsContentPageComponent implements OnInit, OnDestroy {
                   if (docs.demo.embedded) {
                     docs.demo.embedded.forEach(page => {
                       page.githubUrl = this.createGithubUrl(page.slug);
-                      page.url = this.createDemoUrl(page.slug, true);
-                      page.trustedUrl = this.sanitizer.bypassSecurityTrustResourceUrl(page.url);
+                      page.url = this.createDemoUrl(page.slug);
+                      page.trustedUrl = this.sanitizer.bypassSecurityTrustResourceUrl(this.createDemoUrl(page.slug, true));
                     });
                   }
                 }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Only have the iframe use the nofrills url

**Related github/jira issue (required)**:
Fixes #708 

**Steps necessary to review your pull request (required)**:
1. Start the app
1. Go to a component page with iframe examples
1. Click the external link icon above the iframe and make sure the url lack `nofrills` param and that the example load with a header.