### PR TITLE
Improves behavior of demo links opening in new target

### DIFF
--- a/src/web/src/app/components/docs-content-page/docs-content-page.component.ts
+++ b/src/web/src/app/components/docs-content-page/docs-content-page.component.ts
@@ -223,12 +223,17 @@ export class DocsContentPageComponent implements OnInit, OnDestroy {
           const relativeLink = el.getAttribute(attr);
           const pathArray = relativeLink.split('/');
           if (pathArray[1] === 'code' && pathArray[4] === 'demo') {
-            window.open(`${window.location.origin}${relativeLink}`, '_blank');
+            //pass, behave like normal following a click behavior
           } else {
+            event.preventDefault();
             this.router.navigate([`${relativeLink}`]);
           }
         } else {
           const relativeHref = el.getAttribute(attr).replace(/(^\.\/|.html$)/g, '');
+          const pathArray = relativeHref.split('/');
+          if (pathArray.includes('demo')) {
+            el.setAttribute('target', '_blank');
+          }
           if (relativeHref.substring(0, 1) === '/') {
             // Relative to the root of the domain
             el.setAttribute(attr, `${relativeHref}`);
@@ -304,7 +309,6 @@ export class DocsContentPageComponent implements OnInit, OnDestroy {
     const el = event.target as HTMLElement;
     const href = el.getAttribute('href');
     if (!absolute.test(href)) {
-      event.preventDefault();
       if (el.tagName.toLowerCase() === 'a') {
         this.createRelativePath(el, 'href', true);
       }

--- a/src/web/src/app/components/docs-content-page/docs-content-page.component.ts
+++ b/src/web/src/app/components/docs-content-page/docs-content-page.component.ts
@@ -223,7 +223,7 @@ export class DocsContentPageComponent implements OnInit, OnDestroy {
           const relativeLink = el.getAttribute(attr);
           const pathArray = relativeLink.split('/');
           if (pathArray[1] === 'code' && pathArray[4] === 'demo') {
-            //pass, behave like normal following a click behavior
+            // pass, behave like normal following a click behavior
           } else {
             event.preventDefault();
             this.router.navigate([`${relativeLink}`]);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Links would inconsistently open in new tabs. This makes the behavior for docs links more consistent.

**Related github/jira issue (required)**:
#681 

**Steps necessary to review your pull request (required)**:
1. Go to https://staging.design.infor.com/code/ids-enterprise/latest/tooltip
2. `popover` link goes to component page without reloading the whole page
3. Check the "The code above is demoed..." links to make sure they open in a new tab

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
