### PR TITLE
765 - CMS sidebar show_in_menu

### DIFF
--- a/src/app/home/router.py
+++ b/src/app/home/router.py
@@ -48,13 +48,14 @@ class CustomPageAPIEndpoint(PagesAPIEndpoint):
         'children',
         'parent',
         'menu_order',
+        'show_in_menus',
     ]
 
     # Leaving this just in case if somewhere in the app we still
     # use the "&has_children=false/true" url parameter.
     known_query_parameters = PagesAPIEndpoint.known_query_parameters.union([
         'preview',
-        'has_children'
+        'has_children',
     ])
 
     # Including all of the below just for reference,

--- a/src/app/home/serializers.py
+++ b/src/app/home/serializers.py
@@ -52,6 +52,7 @@ def get_children_hirarchy(obj):
         ('children_count', children_count),
         ('children', children_list),
         ('menu_order', menu_order),
+        ('show_in_menus', obj.show_in_menus),
     ])
 
 

--- a/src/site/src/app/app.module.ts
+++ b/src/site/src/app/app.module.ts
@@ -36,6 +36,7 @@ import { FilterPipeModule } from './shared/filter.pipe.module';
 import { BackToTopComponent } from './components/back-to-top/back-to-top.component';
 import { InputFocusDirective } from './shared/input-focus.directive';
 import { ScrollSpyDirective } from './shared/scroll-spy.directive';
+import { SortPipe } from './shared/sort.pipe';
 
 @NgModule({
   declarations: [
@@ -65,6 +66,7 @@ import { ScrollSpyDirective } from './shared/scroll-spy.directive';
     BackToTopComponent,
     InputFocusDirective,
     ScrollSpyDirective,
+    SortPipe,
   ],
   imports: [
     BrowserModule,

--- a/src/site/src/app/components/home/home.component.scss
+++ b/src/site/src/app/components/home/home.component.scss
@@ -337,8 +337,8 @@
     }
 
     p {
-      margin-top: 0;
       margin-bottom: calc(var(--theme-number-spacing-base) * 4);
+      margin-top: 0;
 
       @media screen and (max-width: $breakpoint-sm) {
         font-size: var(--theme-size-font-xs);
@@ -408,17 +408,17 @@
 }
 
 .row--design-tokens--animation {
-  position: relative;
-	padding-bottom: 56.25%;
-	padding-top: 25px;
   height: 0;
+  padding-bottom: 56.25%;
+  padding-top: 25px;
+  position: relative;
 
   video {
+    height: 100%;
+    left: 0;
     position: absolute;
     top: 0;
-    left: 0;
     width: 100%;
-    height: 100%;
   }
 }
 

--- a/src/site/src/app/components/sidebar-cms/sidebar-cms.component.html
+++ b/src/site/src/app/components/sidebar-cms/sidebar-cms.component.html
@@ -6,7 +6,7 @@
       <li><a class="ids-list--item" [routerLink]="['.']" routerLinkActive="ids-list--item--selected"
           [routerLinkActiveOptions]="{exact: true}" (click)="closeSidebar()">{{sectionTitle}}</a></li>
 
-      <li *ngFor="let item of sidebarNav">
+      <li *ngFor="let item of sidebarNav | sort: 'title';">
         <span *ngIf="item.meta.children.children_count > 0" (click)="helpers.toggleAccordion(i, expandedLevel1)"
           class="ids-list--heading-accordion ids-list--heading-accordion--active"
           [class.ids-list--heading-accordion--active]="!expandedLevel1[i]">
@@ -20,7 +20,7 @@
           routerLinkActive="ids-list--item--selected" (click)="closeSidebar()">{{item.title}}</a>
 
         <ul class="ids-list ids-list--expandable" [class.ids-list--expanded]="!expandedLevel1[i]">
-          <li *ngFor="let level_2 of item.meta.children.children; let i = index">
+          <li *ngFor="let level_2 of item.meta.children.children | sort: 'title'; let i = index;">
 
             <a class="ids-list--item" routerLinkActive="ids-list--item--selected"
               routerLink="{{level_2.relative_url}}" (click)="closeSidebar()">

--- a/src/site/src/app/components/sidebar-cms/sidebar-cms.component.html
+++ b/src/site/src/app/components/sidebar-cms/sidebar-cms.component.html
@@ -5,7 +5,43 @@
     <ul class="ids-list ids-list--hover">
       <li><a class="ids-list--item" [routerLink]="['.']" routerLinkActive="ids-list--item--selected"
           [routerLinkActiveOptions]="{exact: true}" (click)="closeSidebar()">{{sectionTitle}}</a></li>
-      <ng-container *ngFor="let child of sidebarNav; let i = index">
+          <li *ngFor="let item of sidebarNav">
+            <span *ngIf="item.meta.children.children_count > 0" (click)="helpers.toggleAccordion(i, expandedLevel1)"
+              class="ids-list--heading-accordion ids-list--heading-accordion--active"
+              [class.ids-list--heading-accordion--active]="!expandedLevel1[i]">
+              {{item.title}}
+              <svg class="ids-icon" focusable="false" aria-hidden="true" role="presentation">
+                <use xlink:href="#icon_expand"></use>
+              </svg>
+            </span>
+
+            <a *ngIf="item.meta.children.children_count <= 0" class="ids-list--item" routerLink="{{item.meta.slug}}"
+              routerLinkActive="ids-list--item--selected" (click)="closeSidebar()">{{item.title}}</a>
+
+            <ul class="ids-list ids-list--expandable" [class.ids-list--expanded]="!expandedLevel1[i]">
+              <li *ngFor="let level_2 of item.meta.children.children; let i = index">
+
+                <a *ngIf="level_2.children_count <= 0" class="ids-list--item" routerLinkActive="ids-list--item--selected"
+                  routerLink="{{level_2.relative_url}}" (click)="closeSidebar()">
+                  {{level_2.title}}
+                </a>
+
+                <span *ngIf="level_2.children_count > 0"
+                  class="ids-list--item ids-list--heading ids-list--heading-accordion--active">
+                  {{level_2.title}}
+                </span>
+
+                <ul class="ids-list ids-list--expandable ids-list--expanded">
+                  <li *ngFor="let level_3 of level_2.children">
+                    <a class="ids-list--item" routerLinkActive="ids-list--item--selected" routerLink="{{level_3.relative_url}}"
+                      (click)="closeSidebar()">{{level_3.title}}</a>
+                  </li>
+                </ul>
+
+              </li>
+            </ul>
+          </li>
+      <!-- <ng-container *ngFor="let child of sidebarNav; let i = index">
 
         <li>
           <span *ngIf="child.children && child.children.length > 0" (click)="helpers.toggleAccordion(i, expandedLevel1)"
@@ -52,7 +88,7 @@
           </ul>
         </li>
 
-      </ng-container>
+      </ng-container> -->
 
     </ul>
   </nav>

--- a/src/site/src/app/components/sidebar-cms/sidebar-cms.component.html
+++ b/src/site/src/app/components/sidebar-cms/sidebar-cms.component.html
@@ -5,90 +5,31 @@
     <ul class="ids-list ids-list--hover">
       <li><a class="ids-list--item" [routerLink]="['.']" routerLinkActive="ids-list--item--selected"
           [routerLinkActiveOptions]="{exact: true}" (click)="closeSidebar()">{{sectionTitle}}</a></li>
-          <li *ngFor="let item of sidebarNav">
-            <span *ngIf="item.meta.children.children_count > 0" (click)="helpers.toggleAccordion(i, expandedLevel1)"
-              class="ids-list--heading-accordion ids-list--heading-accordion--active"
-              [class.ids-list--heading-accordion--active]="!expandedLevel1[i]">
-              {{item.title}}
-              <svg class="ids-icon" focusable="false" aria-hidden="true" role="presentation">
-                <use xlink:href="#icon_expand"></use>
-              </svg>
-            </span>
 
-            <a *ngIf="item.meta.children.children_count <= 0" class="ids-list--item" routerLink="{{item.meta.slug}}"
-              routerLinkActive="ids-list--item--selected" (click)="closeSidebar()">{{item.title}}</a>
+      <li *ngFor="let item of sidebarNav">
+        <span *ngIf="item.meta.children.children_count > 0" (click)="helpers.toggleAccordion(i, expandedLevel1)"
+          class="ids-list--heading-accordion ids-list--heading-accordion--active"
+          [class.ids-list--heading-accordion--active]="!expandedLevel1[i]">
+          {{item.title}}
+          <svg class="ids-icon" focusable="false" aria-hidden="true" role="presentation">
+            <use xlink:href="#icon_expand"></use>
+          </svg>
+        </span>
 
-            <ul class="ids-list ids-list--expandable" [class.ids-list--expanded]="!expandedLevel1[i]">
-              <li *ngFor="let level_2 of item.meta.children.children; let i = index">
+        <a *ngIf="item.meta.children.children_count <= 0" class="ids-list--item" routerLink="{{item.meta.slug}}"
+          routerLinkActive="ids-list--item--selected" (click)="closeSidebar()">{{item.title}}</a>
 
-                <a *ngIf="level_2.children_count <= 0" class="ids-list--item" routerLinkActive="ids-list--item--selected"
-                  routerLink="{{level_2.relative_url}}" (click)="closeSidebar()">
-                  {{level_2.title}}
-                </a>
+        <ul class="ids-list ids-list--expandable" [class.ids-list--expanded]="!expandedLevel1[i]">
+          <li *ngFor="let level_2 of item.meta.children.children; let i = index">
 
-                <span *ngIf="level_2.children_count > 0"
-                  class="ids-list--item ids-list--heading ids-list--heading-accordion--active">
-                  {{level_2.title}}
-                </span>
+            <a class="ids-list--item" routerLinkActive="ids-list--item--selected"
+              routerLink="{{level_2.relative_url}}" (click)="closeSidebar()">
+              {{level_2.title}}
+            </a>
 
-                <ul class="ids-list ids-list--expandable ids-list--expanded">
-                  <li *ngFor="let level_3 of level_2.children">
-                    <a class="ids-list--item" routerLinkActive="ids-list--item--selected" routerLink="{{level_3.relative_url}}"
-                      (click)="closeSidebar()">{{level_3.title}}</a>
-                  </li>
-                </ul>
-
-              </li>
-            </ul>
           </li>
-      <!-- <ng-container *ngFor="let child of sidebarNav; let i = index">
-
-        <li>
-          <span *ngIf="child.children && child.children.length > 0" (click)="helpers.toggleAccordion(i, expandedLevel1)"
-            class="ids-list--heading-accordion ids-list--heading-accordion--active"
-            [class.ids-list--heading-accordion--active]="!expandedLevel1[i]">
-            {{child.title}}
-            <svg class="ids-icon" focusable="false" aria-hidden="true" role="presentation">
-              <use xlink:href="#icon_expand"></use>
-            </svg>
-          </span>
-
-          <a *ngIf="child.children.length <= 0" class="ids-list--item" routerLink="{{child.slug}}"
-            routerLinkActive="ids-list--item--selected" (click)="closeSidebar()">{{child.title}}</a>
-
-          <ul class="ids-list ids-list--expandable" [class.ids-list--expanded]="!expandedLevel1[i]">
-            <li *ngFor="let level_2 of child.children; let i = index">
-
-              <a
-                *ngIf="level_2.children.length <= 0"
-                class="ids-list--item"
-                routerLinkActive="ids-list--item--selected"
-                routerLink="{{level_2.relative_url}}"
-                (click)="closeSidebar()"
-              >
-                {{level_2.title}}
-              </a>
-
-              <span *ngIf="level_2.children && level_2.children.length > 0" class="ids-list--item ids-list--heading ids-list--heading-accordion--active">
-                {{level_2.title}}
-              </span>
-
-              <ul class="ids-list ids-list--expandable ids-list--expanded">
-                <li *ngFor="let level_3 of level_2.children">
-                  <a
-                    class="ids-list--item"
-                    routerLinkActive="ids-list--item--selected"
-                    routerLink="{{level_3.relative_url}}"
-                    (click)="closeSidebar()"
-                  >{{level_3.title}}</a>
-                </li>
-              </ul>
-
-            </li>
-          </ul>
-        </li>
-
-      </ng-container> -->
+        </ul>
+      </li>
 
     </ul>
   </nav>

--- a/src/site/src/app/components/sidebar-cms/sidebar-cms.component.html
+++ b/src/site/src/app/components/sidebar-cms/sidebar-cms.component.html
@@ -20,14 +20,16 @@
           routerLinkActive="ids-list--item--selected" (click)="closeSidebar()">{{item.title}}</a>
 
         <ul class="ids-list ids-list--expandable" [class.ids-list--expanded]="!expandedLevel1[i]">
-          <li *ngFor="let level_2 of item.meta.children.children | sort: 'title'; let i = index;">
+          <ng-container *ngFor="let level_2 of item.meta.children.children | sort: 'title'; let i = index;">
+            <li *ngIf="level_2.show_in_menus === true">
 
-            <a class="ids-list--item" routerLinkActive="ids-list--item--selected"
-              routerLink="{{level_2.relative_url}}" (click)="closeSidebar()">
-              {{level_2.title}}
-            </a>
+              <a class="ids-list--item" routerLinkActive="ids-list--item--selected"
+                routerLink="{{level_2.relative_url}}" (click)="closeSidebar()">
+                {{level_2.title}}
+              </a>
 
-          </li>
+            </li>
+          </ng-container>
         </ul>
       </li>
 

--- a/src/site/src/app/components/sidebar-cms/sidebar-cms.component.html
+++ b/src/site/src/app/components/sidebar-cms/sidebar-cms.component.html
@@ -6,7 +6,7 @@
       <li><a class="ids-list--item" [routerLink]="['.']" routerLinkActive="ids-list--item--selected"
           [routerLinkActiveOptions]="{exact: true}" (click)="closeSidebar()">{{parentTitle | titlecase}}</a></li>
 
-      <li *ngFor="let item of sidebarNav | sort: 'title';">
+      <li *ngFor="let item of sidebarNav | sort: 'title'; let i = index">
         <span *ngIf="item.meta.children.children_count > 0" (click)="helpers.toggleAccordion(i, expandedLevel1)"
           class="ids-list--heading-accordion ids-list--heading-accordion--active"
           [class.ids-list--heading-accordion--active]="!expandedLevel1[i]">

--- a/src/site/src/app/components/sidebar-cms/sidebar-cms.component.html
+++ b/src/site/src/app/components/sidebar-cms/sidebar-cms.component.html
@@ -4,7 +4,7 @@
   <nav class="sidebar-nav sidebar-nav-list">
     <ul class="ids-list ids-list--hover">
       <li><a class="ids-list--item" [routerLink]="['.']" routerLinkActive="ids-list--item--selected"
-          [routerLinkActiveOptions]="{exact: true}" (click)="closeSidebar()">{{sectionTitle}}</a></li>
+          [routerLinkActiveOptions]="{exact: true}" (click)="closeSidebar()">{{parentTitle | titlecase}}</a></li>
 
       <li *ngFor="let item of sidebarNav | sort: 'title';">
         <span *ngIf="item.meta.children.children_count > 0" (click)="helpers.toggleAccordion(i, expandedLevel1)"

--- a/src/site/src/app/components/sidebar-cms/sidebar-cms.component.ts
+++ b/src/site/src/app/components/sidebar-cms/sidebar-cms.component.ts
@@ -31,55 +31,73 @@ export class SidebarCmsComponent implements OnInit {
     preview ? this.section = previewSlug[0] : this.section = urlSegments[0].path;
 
     this.loading = true;
-    this.pagesService.getAll().subscribe(
-      (res) => {
-        res['items'].filter((item) => {
-          if (item.meta.slug === this.section) {
-            if (item.meta.children.children.length === 1 && item.meta.children.children[0].children_count === 0) {
-              this.level_2 = false;
-            }
-            this.sidebarNav = item.meta.children.children.sort((thisChild, nextChild) => {
-              item.meta.children.children.map(child => {
-                child.children.length <= 0 ? this.level_2 = false : this.level_2 = true;
-                child.children.sort((thisGrandChild, nextGrandchild) => {
-                  if (thisGrandChild.menu_order === 0 && nextGrandchild.menu_order === 0) {
-                    return thisGrandChild.title.toLowerCase() > nextGrandchild.title.toLowerCase() ? 1 : -1;
-                  } else {
-                    return thisGrandChild.menu_order > nextGrandchild.menu_order ? 1 : -1;
-                  }
-                });
-                child.children
-                  .filter(child_level_3 => {
-                    if (child_level_3.children && child_level_3.children.length > 0) {
-                      child_level_3.children.sort((thisChild_level_3, nextChild_level_3) => {
-                        return thisChild_level_3.title > nextChild_level_3.title ? 1 : -1;
-                      });
-                    }
-                  });
-              });
-              this.sectionTitle = item.title;
-              if (thisChild.menu_order === 0 && nextChild.menu_order === 0) {
-                return thisChild.title.toLowerCase() > nextChild.title.toLowerCase() ? 1 : -1;
-              } else {
-                return thisChild.menu_order > nextChild.menu_order ? 1 : -1;
-              }
-            });
-            if (this.helpers.checkViewport('(min-width: 600px)')) {
-              setTimeout(() => {
-                this.expandedLevel1 = this.helpers.closeAccordionsMobile(this.sidebarNav);
-              });
-            }
-          }
-        });
-      },
-      (err) => {
-        this.loading = false;
-        console.error(err);
-      },
-      () => {
-        this.loading = false;
-      }
-    );
+    this.sectionTitle = this.section;
+    this.pagesService.getCMSSidebarParent(this.section)
+      .subscribe(res => {
+        this.pagesService.getCMSSidebarNav(res['items'][0]['id'])
+          .subscribe(res => {
+            this.sidebarNav = res['items'];
+            console.log(this.sidebarNav);
+            // this.sidebarNav = res['items'].map(item => {
+            //   console.log(item);
+            //   this.sectionTitle = item.title;
+            //   //Not sure what this is checking.
+            //   if (item.meta.children.children_count === 0) {
+            //     this.level_2 = false;
+            //   }
+            // });
+            // console.log(this.sidebarNav);
+          })
+      })
+    // this.pagesService.getAll().subscribe(
+    //   (res) => {
+    //     res['items'].filter((item) => {
+    //       if (item.meta.slug === this.section) {
+    //         if (item.meta.children.children.length === 1 && item.meta.children.children[0].children_count === 0) {
+    //           this.level_2 = false;
+    //         }
+    //         this.sidebarNav = item.meta.children.children.sort((thisChild, nextChild) => {
+    //           item.meta.children.children.map(child => {
+    //             child.children.length <= 0 ? this.level_2 = false : this.level_2 = true;
+    //             child.children.sort((thisGrandChild, nextGrandchild) => {
+    //               if (thisGrandChild.menu_order === 0 && nextGrandchild.menu_order === 0) {
+    //                 return thisGrandChild.title.toLowerCase() > nextGrandchild.title.toLowerCase() ? 1 : -1;
+    //               } else {
+    //                 return thisGrandChild.menu_order > nextGrandchild.menu_order ? 1 : -1;
+    //               }
+    //             });
+    //             child.children
+    //               .filter(child_level_3 => {
+    //                 if (child_level_3.children && child_level_3.children.length > 0) {
+    //                   child_level_3.children.sort((thisChild_level_3, nextChild_level_3) => {
+    //                     return thisChild_level_3.title > nextChild_level_3.title ? 1 : -1;
+    //                   });
+    //                 }
+    //               });
+    //           });
+    //           this.sectionTitle = item.title;
+    //           if (thisChild.menu_order === 0 && nextChild.menu_order === 0) {
+    //             return thisChild.title.toLowerCase() > nextChild.title.toLowerCase() ? 1 : -1;
+    //           } else {
+    //             return thisChild.menu_order > nextChild.menu_order ? 1 : -1;
+    //           }
+    //         });
+    //         if (this.helpers.checkViewport('(min-width: 600px)')) {
+    //           setTimeout(() => {
+    //             this.expandedLevel1 = this.helpers.closeAccordionsMobile(this.sidebarNav);
+    //           });
+    //         }
+    //       }
+    //     });
+    //   },
+    //   (err) => {
+    //     this.loading = false;
+    //     console.error(err);
+    //   },
+    //   () => {
+    //     this.loading = false;
+    //   }
+    // );
 
   }
 

--- a/src/site/src/app/components/sidebar-cms/sidebar-cms.component.ts
+++ b/src/site/src/app/components/sidebar-cms/sidebar-cms.component.ts
@@ -34,71 +34,26 @@ export class SidebarCmsComponent implements OnInit {
     this.sectionTitle = this.section;
     this.pagesService.getCMSSidebarParent(this.section)
       .subscribe(res => {
+        this.loading = true;
         this.pagesService.getCMSSidebarNav(res['items'][0]['id'])
           .subscribe(res => {
             this.sidebarNav = res['items'];
-            console.log(this.sidebarNav);
-            // this.sidebarNav = res['items'].map(item => {
-            //   console.log(item);
-            //   this.sectionTitle = item.title;
-            //   //Not sure what this is checking.
-            //   if (item.meta.children.children_count === 0) {
-            //     this.level_2 = false;
-            //   }
-            // });
-            // console.log(this.sidebarNav);
+          },
+          (err) => {
+            this.loading = false;
+            console.error(err);
+          },
+          () => {
+            this.loading = false;
           })
+      },
+      (err) => {
+        this.loading = false;
+        console.error(err);
+      },
+      () => {
+        this.loading = false;
       })
-    // this.pagesService.getAll().subscribe(
-    //   (res) => {
-    //     res['items'].filter((item) => {
-    //       if (item.meta.slug === this.section) {
-    //         if (item.meta.children.children.length === 1 && item.meta.children.children[0].children_count === 0) {
-    //           this.level_2 = false;
-    //         }
-    //         this.sidebarNav = item.meta.children.children.sort((thisChild, nextChild) => {
-    //           item.meta.children.children.map(child => {
-    //             child.children.length <= 0 ? this.level_2 = false : this.level_2 = true;
-    //             child.children.sort((thisGrandChild, nextGrandchild) => {
-    //               if (thisGrandChild.menu_order === 0 && nextGrandchild.menu_order === 0) {
-    //                 return thisGrandChild.title.toLowerCase() > nextGrandchild.title.toLowerCase() ? 1 : -1;
-    //               } else {
-    //                 return thisGrandChild.menu_order > nextGrandchild.menu_order ? 1 : -1;
-    //               }
-    //             });
-    //             child.children
-    //               .filter(child_level_3 => {
-    //                 if (child_level_3.children && child_level_3.children.length > 0) {
-    //                   child_level_3.children.sort((thisChild_level_3, nextChild_level_3) => {
-    //                     return thisChild_level_3.title > nextChild_level_3.title ? 1 : -1;
-    //                   });
-    //                 }
-    //               });
-    //           });
-    //           this.sectionTitle = item.title;
-    //           if (thisChild.menu_order === 0 && nextChild.menu_order === 0) {
-    //             return thisChild.title.toLowerCase() > nextChild.title.toLowerCase() ? 1 : -1;
-    //           } else {
-    //             return thisChild.menu_order > nextChild.menu_order ? 1 : -1;
-    //           }
-    //         });
-    //         if (this.helpers.checkViewport('(min-width: 600px)')) {
-    //           setTimeout(() => {
-    //             this.expandedLevel1 = this.helpers.closeAccordionsMobile(this.sidebarNav);
-    //           });
-    //         }
-    //       }
-    //     });
-    //   },
-    //   (err) => {
-    //     this.loading = false;
-    //     console.error(err);
-    //   },
-    //   () => {
-    //     this.loading = false;
-    //   }
-    // );
-
   }
 
   closeSidebar() {

--- a/src/site/src/app/shared/pages.service.spec.ts
+++ b/src/site/src/app/shared/pages.service.spec.ts
@@ -67,10 +67,40 @@ describe('PagesService', () => {
   });
 
   it('#getGlobalNav should GET the data', () => {
-    const testUrl = `${environment.apiUrl}/api/${environment.domainVersion}/pages/?format=json&show_in_menus=true`;
+    const testUrl = `${environment.apiUrl}/api/${environment.domainVersion}/pages/?format=json&type=home.LandingPage&show_in_menus=true`;
     const testData = { title: 'Test' };
 
     pagesService.getGlobalNav()
+      .subscribe(data =>
+        expect(data).toEqual(testData)
+      );
+
+    const req = httpTestingController.expectOne(testUrl);
+    expect(req.request.method).toEqual('GET');
+    req.flush(testData);
+  });
+
+  it('#getCMSSidebarParent should GET the data', () => {
+    const section = 'testSection';
+    const testUrl = `${environment.apiUrl}/api/${environment.domainVersion}/pages/?format=json&limit=200&slug=${section}`;
+    const testData = { title: 'Test' };
+
+    pagesService.getCMSSidebarParent(section)
+      .subscribe(data =>
+        expect(data).toEqual(testData)
+      );
+
+    const req = httpTestingController.expectOne(testUrl);
+    expect(req.request.method).toEqual('GET');
+    req.flush(testData);
+  });
+
+  it('#getCMSSidebarNav should GET the data', () => {
+    const id = 1;
+    const testUrl = `${environment.apiUrl}/api/${environment.domainVersion}/pages/?format=json&limit=200&child_of=${id}&show_in_menus=true`;
+    const testData = { title: 'Test' };
+
+    pagesService.getCMSSidebarNav(id)
       .subscribe(data =>
         expect(data).toEqual(testData)
       );

--- a/src/site/src/app/shared/pages.service.ts
+++ b/src/site/src/app/shared/pages.service.ts
@@ -18,7 +18,15 @@ export class PagesService {
   ) { }
 
   getGlobalNav() {
-    return this.http.get(`${this.apiUrl}/api/${this.domainVersion}/pages/?format=json&show_in_menus=true`).pipe(first());
+    return this.http.get(`${this.apiUrl}/api/${this.domainVersion}/pages/?format=json&type=home.LandingPage&show_in_menus=true`).pipe(first());
+  }
+
+  getCMSSidebarParent(section: string) {
+    return this.http.get(`${this.apiUrl}/api/${this.domainVersion}/pages/?format=json&limit=200&slug=${section}`).pipe(first());
+  }
+
+  getCMSSidebarNav(id: number) {
+    return this.http.get(`${this.apiUrl}/api/${this.domainVersion}/pages/?format=json&limit=200&child_of=${id}&show_in_menus=true`).pipe(first());
   }
 
   getAll() {

--- a/src/site/src/app/shared/pages.service.ts
+++ b/src/site/src/app/shared/pages.service.ts
@@ -22,11 +22,13 @@ export class PagesService {
   }
 
   getCMSSidebarParent(section: string) {
-    return this.http.get(`${this.apiUrl}/api/${this.domainVersion}/pages/?format=json&limit=200&slug=${section}`).pipe(first());
+    const url = `${this.apiUrl}/api/${this.domainVersion}/pages/?format=json&limit=200&slug=${section}`;
+    return this.cacheService.get(url, this.http.get(url).pipe(first()));
   }
 
   getCMSSidebarNav(id: number) {
-    return this.http.get(`${this.apiUrl}/api/${this.domainVersion}/pages/?format=json&limit=200&child_of=${id}&show_in_menus=true`).pipe(first());
+    const url = `${this.apiUrl}/api/${this.domainVersion}/pages/?format=json&limit=200&child_of=${id}&show_in_menus=true`;
+    return this.cacheService.get(url, this.http.get(url).pipe(first()));
   }
 
   getAll() {

--- a/src/site/src/app/shared/pages.service.ts
+++ b/src/site/src/app/shared/pages.service.ts
@@ -18,7 +18,8 @@ export class PagesService {
   ) { }
 
   getGlobalNav() {
-    return this.http.get(`${this.apiUrl}/api/${this.domainVersion}/pages/?format=json&type=home.LandingPage&show_in_menus=true`).pipe(first());
+    const url = `${this.apiUrl}/api/${this.domainVersion}/pages/?format=json&type=home.LandingPage&show_in_menus=true`;
+    return this.http.get(url).pipe(first());
   }
 
   getCMSSidebarParent(section: string) {

--- a/src/site/src/app/shared/sort.pipe.ts
+++ b/src/site/src/app/shared/sort.pipe.ts
@@ -1,0 +1,24 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'sort'
+})
+export class SortPipe implements PipeTransform {
+
+  transform(array: any, field: string): any {
+    if (!Array.isArray(array)) {
+      return;
+    }
+    array.sort((a: any, b: any) => {
+      if (a[field] < b[field]) {
+        return -1;
+      } else if (a[field] > b[field]) {
+        return 1;
+      } else {
+        return 0;
+      }
+    });
+    return array;
+  }
+
+}

--- a/src/site/src/assets/css/sidebar.scss
+++ b/src/site/src/assets/css/sidebar.scss
@@ -40,6 +40,7 @@
   display: block;
   position: absolute;
   right: 0;
+  z-index: 2;
 
   @media screen and (min-width: $breakpoint-sm) {
     display: none;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Gives us the ability to utilize the "Show in Menu" function in the CMS. Had to change the globalNav service to only get page of type `home.LandingPage`

**Related github/jira issue (required)**:
closes #765 

**Steps necessary to review your pull request (required)**:
1. login to CMS and set "Show in Menu" true for all pages that should be in the sidebar nav.
2. check front end and make sure nav items are showing properly.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
