### PR TITLE
771 - responsive tables

### DIFF
--- a/src/site/src/app/components/core-content-page/core-content-page.component.html
+++ b/src/site/src/app/components/core-content-page/core-content-page.component.html
@@ -21,7 +21,7 @@
         <section class="page-section" *ngIf="pageContent">
           <ng-container *ngFor="let streamfield of pageContent.body">
             <h2 *ngIf="streamfield.type === 'heading'">{{streamfield?.value}}</h2>
-            <div *ngIf="streamfield.type === 'table'">
+            <div class="table-container" *ngIf="streamfield.type === 'table'">
               <table>
                 <ng-container *ngIf="streamfield.value.first_row_is_table_header; then thBlock; else tdBlock;">
                 </ng-container>

--- a/src/site/src/app/components/token-table/token-table.component.html
+++ b/src/site/src/app/components/token-table/token-table.component.html
@@ -2,86 +2,90 @@
   <section [ngClass]="{'page-section': sectionClassName}">
     <h2 *ngIf="heading">{{heading}}</h2>
 
-    <table *ngIf="!displayAllTokens && idsTokenProperties?.length > 0">
-      <thead>
-        <th>
-          Design Token &nbsp;
-          <a class="table-header--description" href="https://github.com/infor-design/design-system/tree/master/design-tokens"
-            target="_blank">Learn More</a>
-        </th>
-        <th>Color</th>
-        <th>Value</th>
-      </thead>
-      <tbody>
-        <tr *ngFor="let token of idsTokenProperties">
-          <td>
-            <code>{{token.name.sass}}</code>
-          </td>
-          <td>
-            <div *ngIf="token.type === 'color'" class="site-spec--color" [ngStyle]="token.value && {'background-color': ''+ token.value +'' }"
-              title="{{token.value}}"></div>
-          </td>
-          <td>
-            <code>{{token.value}}</code>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+    <div class="table-container">
 
-    <table *ngIf="displayAllTokens" class="table--wide">
-      <colgroup span="2"></colgroup>
-      <colgroup span="2"></colgroup>
-      <colgroup span="2"></colgroup>
-      <thead>
-        <tr>
-          <th class="token-table--col-name">
+      <table *ngIf="!displayAllTokens && idsTokenProperties?.length > 0">
+        <thead>
+          <th>
             Design Token &nbsp;
             <a class="table-header--description" href="https://github.com/infor-design/design-system/tree/master/design-tokens"
               target="_blank">Learn More</a>
           </th>
-          <th colspan="2" scope="colgroup" class="token-table--col-grouped">Default Theme</th>
-          <th colspan="2" scope="colgroup" class="token-table--col-grouped">Dark Theme</th>
-          <th colspan="2" scope="colgroup" class="token-table--col-grouped">Contrast Theme</th>
-        </tr>
-        <tr>
-          <th></th>
-          <th class="token-table--col-color token-table--col-grouped">Color</th>
-          <th class="token-table--col-value token-table--col-grouped">Value</th>
-          <th class="token-table--col-color token-table--col-grouped">Color</th>
-          <th class="token-table--col-value token-table--col-grouped">Value</th>
-          <th class="token-table--col-color token-table--col-grouped">Color</th>
-          <th class="token-table--col-value token-table--col-grouped">Value</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr *ngFor="let key of objectKeys(idsTokenProperties)" id="{{key.substring(1)}}">
-          <td>
-            <code>{{key}}</code>
-          </td>
-          <td>
-            <div *ngIf="idsTokenProperties[key].soho.type === 'color'" class="site-spec--color" [ngStyle]="idsTokenProperties[key].soho.value && {'background-color': ''+ idsTokenProperties[key].soho.value +'' }"
-              title="{{idsTokenProperties[key].soho.value}}"></div>
-          </td>
-          <td class="token-table--data-value">
-            <code>{{idsTokenProperties[key].soho.value}}</code>
-          </td>
-          <td>
-            <div *ngIf="idsTokenProperties[key].dark.type === 'color'" class="site-spec--color" [ngStyle]="idsTokenProperties[key].dark.value && {'background-color': ''+ idsTokenProperties[key].dark.value +'' }"
-              title="{{idsTokenProperties[key].dark.value}}"></div>
-          </td>
-          <td class="token-table--data-value">
-            <code>{{idsTokenProperties[key].dark.value}}</code>
-          </td>
-          <td>
-            <div *ngIf="idsTokenProperties[key].contrast.type === 'color'" class="site-spec--color" [ngStyle]="idsTokenProperties[key].contrast.value && {'background-color': ''+ idsTokenProperties[key].contrast.value +'' }"
-              title="{{idsTokenProperties[key].contrast.value}}"></div>
-          </td>
-          <td class="token-table--data-value">
-            <code>{{idsTokenProperties[key].contrast.value}}</code>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+          <th>Color</th>
+          <th>Value</th>
+        </thead>
+        <tbody>
+          <tr *ngFor="let token of idsTokenProperties">
+            <td>
+              <code>{{token.name.sass}}</code>
+            </td>
+            <td>
+              <div *ngIf="token.type === 'color'" class="site-spec--color" [ngStyle]="token.value && {'background-color': ''+ token.value +'' }"
+                title="{{token.value}}"></div>
+            </td>
+            <td>
+              <code>{{token.value}}</code>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <table *ngIf="displayAllTokens" class="table--wide">
+        <colgroup span="2"></colgroup>
+        <colgroup span="2"></colgroup>
+        <colgroup span="2"></colgroup>
+        <thead>
+          <tr>
+            <th class="token-table--col-name">
+              Design Token &nbsp;
+              <a class="table-header--description" href="https://github.com/infor-design/design-system/tree/master/design-tokens"
+                target="_blank">Learn More</a>
+            </th>
+            <th colspan="2" scope="colgroup" class="token-table--col-grouped">Default Theme</th>
+            <th colspan="2" scope="colgroup" class="token-table--col-grouped">Dark Theme</th>
+            <th colspan="2" scope="colgroup" class="token-table--col-grouped">Contrast Theme</th>
+          </tr>
+          <tr>
+            <th></th>
+            <th class="token-table--col-color token-table--col-grouped">Color</th>
+            <th class="token-table--col-value token-table--col-grouped">Value</th>
+            <th class="token-table--col-color token-table--col-grouped">Color</th>
+            <th class="token-table--col-value token-table--col-grouped">Value</th>
+            <th class="token-table--col-color token-table--col-grouped">Color</th>
+            <th class="token-table--col-value token-table--col-grouped">Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr *ngFor="let key of objectKeys(idsTokenProperties)" id="{{key.substring(1)}}">
+            <td>
+              <code>{{key}}</code>
+            </td>
+            <td>
+              <div *ngIf="idsTokenProperties[key].soho.type === 'color'" class="site-spec--color" [ngStyle]="idsTokenProperties[key].soho.value && {'background-color': ''+ idsTokenProperties[key].soho.value +'' }"
+                title="{{idsTokenProperties[key].soho.value}}"></div>
+            </td>
+            <td class="token-table--data-value">
+              <code>{{idsTokenProperties[key].soho.value}}</code>
+            </td>
+            <td>
+              <div *ngIf="idsTokenProperties[key].dark.type === 'color'" class="site-spec--color" [ngStyle]="idsTokenProperties[key].dark.value && {'background-color': ''+ idsTokenProperties[key].dark.value +'' }"
+                title="{{idsTokenProperties[key].dark.value}}"></div>
+            </td>
+            <td class="token-table--data-value">
+              <code>{{idsTokenProperties[key].dark.value}}</code>
+            </td>
+            <td>
+              <div *ngIf="idsTokenProperties[key].contrast.type === 'color'" class="site-spec--color" [ngStyle]="idsTokenProperties[key].contrast.value && {'background-color': ''+ idsTokenProperties[key].contrast.value +'' }"
+                title="{{idsTokenProperties[key].contrast.value}}"></div>
+            </td>
+            <td class="token-table--data-value">
+              <code>{{idsTokenProperties[key].contrast.value}}</code>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+    </div>
   </section>
 </ng-container>
 

--- a/src/site/src/assets/css/tables.scss
+++ b/src/site/src/assets/css/tables.scss
@@ -90,3 +90,7 @@ table .table-header--description {
 .table--wide th.token-table--col-color {
   width: 5%;
 }
+
+.table-container {
+  overflow-x: auto;
+}


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Added a scrollable container to tables.

**Related github/jira issue (required)**:
related to #771 

Need to add the container to the documentation template `docs/templates/documentationjs/theme-ids-website/section._` in enterprise to get this working on those tables:

```
  <% if (section.params.length) { %>
    <table class="jsdoc-parameters">
      <caption class="jsdoc-section--heading">Parameters</caption>
      <colgroup>
        <col width='30%' />
        <col width='20%' />
        <col width='50%' />
      </colgroup>
```

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
