### PR TITLE
Update css-var-ponyfill

### DIFF
--- a/src/site/package.json
+++ b/src/site/package.json
@@ -24,7 +24,7 @@
     "@angular/platform-browser-dynamic": "~8.0.0",
     "@angular/router": "~8.0.0",
     "core-js": "^2.5.4",
-    "css-vars-ponyfill": "1.17.1",
+    "css-vars-ponyfill": "2.0.2",
     "flickity-fade": "1.0.0",
     "ng-inline-svg": "8.3.0",
     "polyfill-array-includes": "2.0.0",

--- a/src/site/src/polyfills.ts
+++ b/src/site/src/polyfills.ts
@@ -37,14 +37,14 @@ import 'core-js/es6/reflect';
  * user can disable parts of macroTask/DomEvents patch by setting following flags
  */
 
- // (window as any).__Zone_disable_requestAnimationFrame = true; // disable patch requestAnimationFrame
- // (window as any).__Zone_disable_on_property = true; // disable patch onProperty such as onclick
- // (window as any).__zone_symbol__BLACK_LISTED_EVENTS = ['scroll', 'mousemove']; // disable patch specified eventNames
+// (window as any).__Zone_disable_requestAnimationFrame = true; // disable patch requestAnimationFrame
+// (window as any).__Zone_disable_on_property = true; // disable patch onProperty such as onclick
+// (window as any).__zone_symbol__BLACK_LISTED_EVENTS = ['scroll', 'mousemove']; // disable patch specified eventNames
 
- /*
- * in IE/Edge developer tools, the addEventListener will also be wrapped by zone.js
- * with the following flag, it will bypass `zone.js` patch for IE/Edge
- */
+/*
+* in IE/Edge developer tools, the addEventListener will also be wrapped by zone.js
+* with the following flag, it will bypass `zone.js` patch for IE/Edge
+*/
 // (window as any).__Zone_enable_cross_context_check = true;
 
 /***************************************************************************************************
@@ -57,9 +57,9 @@ import 'zone.js/dist/zone';  // Included with Angular CLI.
  * APPLICATION IMPORTS
  */
 
- /**
-  * Support css custom properties in IE11
-  */
+/**
+ * Support css custom properties in IE11
+ */
 import cssVars from 'css-vars-ponyfill';
 cssVars({
   shadowDOM: true


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
`css-var-ponyfill` was not working in ng8. Updating to `2.0.2` appears to fix the issue.

**Related github/jira issue (required)**:
n/a

**Steps necessary to review your pull request (required)**:
- deploy to staging
- test in IE11

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
