### PR TITLE
You don't need to export any vars to the shell if your using .env file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ DOCS_API_KEY=<DOCS_API_KEY>
 then...
 
 ```bash
-export $(cat .env | xargs)
 make up
 make syncdb
 make migrate


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
The export of .env file vars is redundant.

**Related github/jira issue (required)**:
https://jira.infor.com/browse/HLO-146

**Steps necessary to review your pull request (required)**:
Open a new clean shell, populate the .env file,  and run `docker-compose config` to see the configuration populated.
